### PR TITLE
feat: session tracking

### DIFF
--- a/.changeset/salty-streets-ring.md
+++ b/.changeset/salty-streets-ring.md
@@ -1,0 +1,5 @@
+---
+"react-native-open-telemetry": minor
+---
+
+sessions: trace correlation based on the session.id attribute

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -8,6 +8,11 @@ const sdk = openTelemetrySDK({
   name: "MyExampleApp",
   version: "1.0.0-alpha",
   environment: "development",
+  features: {
+    session: {
+      getSessionId: () => "custom-session-id",
+    },
+  },
 });
 
 const tracer = sdk.trace.getTracer("my-js-tracer");
@@ -78,8 +83,8 @@ export default function App() {
         onPress={() => {
           fetch("https://api.weatherstack.com/current?query=Portland")
             .then((response) => response.json())
-            .then(data => console.log(data))
-            .catch(error => console.error(error))
+            .then((data) => console.log(data))
+            .catch((error) => console.error(error));
         }}
       >
         <Text>Fetch weather</Text>

--- a/src/SessionIdProcessor.ts
+++ b/src/SessionIdProcessor.ts
@@ -1,0 +1,32 @@
+import type { Context } from "@opentelemetry/api";
+import type {
+  Span,
+  SpanProcessor,
+  ReadableSpan,
+} from "@opentelemetry/sdk-trace-base";
+
+type GetSessionId = () => string | null;
+
+export class SessionIdProcessor implements SpanProcessor {
+  getSessionId: GetSessionId;
+
+  constructor(getSessionId: GetSessionId) {
+    this.getSessionId = getSessionId;
+  }
+
+  onStart(span: Span, _parentContext: Context): void {
+    const sessionId = this.getSessionId();
+    if (!sessionId) return;
+    span.setAttribute("session.id", sessionId);
+  }
+
+  onEnd(_span: ReadableSpan): void {}
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -27,6 +27,7 @@ import {
   ATTR_SERVICE_NAME,
   ATTR_SERVICE_VERSION,
 } from "@opentelemetry/semantic-conventions";
+import { SessionIdProcessor } from "./SessionIdProcessor";
 import type { Options } from "./types";
 
 export function openTelemetrySDK(options: Options = {}) {
@@ -60,12 +61,16 @@ export function openTelemetrySDK(options: Options = {}) {
         })
       )
     : null;
+  const sessionSpanProcessor = options.features?.session
+    ? new SessionIdProcessor(options.features.session.getSessionId)
+    : null;
 
   const tracerProvider = new WebTracerProvider({
     resource,
     spanProcessors: [
       logSpanProcessor,
       otlpSpanProcessor,
+      sessionSpanProcessor,
     ].filter((processor) => processor !== null),
   });
 
@@ -84,8 +89,8 @@ export function openTelemetrySDK(options: Options = {}) {
         propagateTraceHeaderCorsUrls: /.*/,
         clearTimingResources: false,
       }),
-    ]
-  })
+    ],
+  });
 
   // Metrics
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,4 +5,9 @@ export interface Options {
   url?: string;
   debug?: boolean;
   native?: boolean;
+  features?: {
+    session?: {
+      getSessionId: () => string | null;
+    };
+  };
 }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR adds a `SessionIdProvider` that attributes all span data with `session.id`.

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->
https://github.com/callstack/react-native-open-telemetry/issues/13

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->
Spans should have `session.id` on them when `options.features.session` is specified.